### PR TITLE
Adds task success report on ensure_block

### DIFF
--- a/queue_worker.rb
+++ b/queue_worker.rb
@@ -40,15 +40,14 @@ module TaskQueue
         # if we have an ensure block to run, run it now
         unless @current_task.ensure_block.nil?
           case @current_task.ensure_block.arity
-            when 0
-              @current_task.ensure_block.call
-            when 1
-              @current_task.ensure_block.call(@current_task.finished_successfully)
-            else
-              raise "Unexpected number of arguments in `ensure_block`, expected 0 or 1, got #{@current_task.ensure_block.arity}"
+          when 0
+            @current_task.ensure_block.call
+          when 1
+            @current_task.ensure_block.call(@current_task.finished_successfully)
+          else
+            raise "Unexpected number of arguments in `ensure_block`, expected 0 or 1, got #{@current_task.ensure_block.arity}"
           end
         end
-        @current_task.ensure_block.call if @current_task.ensure_block
       rescue StandardError => e
         # Oh noes, our ensure block raised something
         puts("finish_task failed with exception: #{e.message}")

--- a/queue_worker.rb
+++ b/queue_worker.rb
@@ -32,10 +32,22 @@ module TaskQueue
         @busy = false
         @current_task.completed = true
         @current_task.completed.freeze # Sorry, you can't run this task again
+        @current_task.finished_successfully = true
+        @current_task.finished_successfully.freeze
       end
 
       begin
         # if we have an ensure block to run, run it now
+        unless @current_task.ensure_block.nil?
+          case @current_task.ensure_block.arity
+            when 0
+              @current_task.ensure_block.call
+            when 1
+              @current_task.ensure_block.call(@current_task.finished_successfully)
+            else
+              raise "Unexpected number of arguments in `ensure_block`, expected 1 or 2, got #{@current_task.ensure_block.arity}"
+          end
+        end
         @current_task.ensure_block.call if @current_task.ensure_block
       rescue StandardError => e
         # Oh noes, our ensure block raised something

--- a/queue_worker.rb
+++ b/queue_worker.rb
@@ -45,7 +45,7 @@ module TaskQueue
             when 1
               @current_task.ensure_block.call(@current_task.finished_successfully)
             else
-              raise "Unexpected number of arguments in `ensure_block`, expected 1 or 2, got #{@current_task.ensure_block.arity}"
+              raise "Unexpected number of arguments in `ensure_block`, expected 0 or 1, got #{@current_task.ensure_block.arity}"
           end
         end
         @current_task.ensure_block.call if @current_task.ensure_block

--- a/specs/work_queue_spec.rb
+++ b/specs/work_queue_spec.rb
@@ -47,6 +47,7 @@ module TaskQueue
       wait_for_task_to_complete(task: task)
       expect(work_completed).to be(true)
       expect(success_task).to be(true)
+      expect(task.finished_successfully).to be(true)
     end
 
     it 'Reports unsuccess state when task completed with exceptions' do
@@ -61,6 +62,7 @@ module TaskQueue
 
       expect(ensured).to be(true)
       expect(success_task).to be(false)
+      expect(task.finished_successfully).to be(false)
     end
 
     it 'Executes 2 blocks of work with just 1 worker' do

--- a/specs/work_queue_spec.rb
+++ b/specs/work_queue_spec.rb
@@ -38,6 +38,31 @@ module TaskQueue
       expect(ensured).to be(true)
     end
 
+    it 'Reports success state when task completed without exceptions' do
+      queue = TaskQueue.new(name: 'test queue')
+      work_completed = false
+      success_task = false
+      task = Task.new(work_block: proc { work_completed = true }, ensure_block: proc { |success| success_task = true })
+      queue.add_task_async(task: task)
+      wait_for_task_to_complete(task: task)
+      expect(work_completed).to be(true)
+      expect(success_task).to be(true)
+    end
+
+    it 'Reports unsuccess state when task completed with exceptions' do
+      ensured = false
+      success_task = nil
+      expect {
+        queue = TaskQueue.new(name: 'test queue')
+        task = Task.new(work_block: proc { raise "Oh noes" }, ensure_block: proc { |success| ensured = true; success_task = success })
+        queue.add_task_async(task: task)
+        wait_for_task_to_complete(task: task)
+      }.to raise_error(RuntimeError, "Oh noes")
+
+      expect(ensured).to be(true)
+      expect(success_task).to be(false)
+    end
+
     it 'Executes 2 blocks of work with just 1 worker' do
       queue = TaskQueue.new(name: 'test queue')
 

--- a/task.rb
+++ b/task.rb
@@ -8,6 +8,7 @@ module TaskQueue
     attr_accessor :ensure_block
     attr_accessor :completed
     attr_accessor :submitted
+    attr_accessor :finished_successfully
 
     def initialize(name: nil, description: nil, work_block: nil, ensure_block: nil)
       self.work_block = work_block
@@ -19,6 +20,7 @@ module TaskQueue
       self.description.freeze
       self.completed = false
       self.submitted = false
+      self.finished_successfully = false
     end
   end
 end


### PR DESCRIPTION
To maintain backwards compatibility (and future additions) I check the `arity` of the `ensure_block` to prevent argument errors.